### PR TITLE
Streamline setup and drop fftx usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 All code contributions should ensure the project runs on machines without GPUs. When adding or editing Python, avoid `.get()` calls on arrays unless you first check that the object has that method.
 
+Agents must run `./run/setup.sh` to install dependencies. This script only
+installs the base requirements and deliberately skips heavyweight optional
+packages such as **Spiral**, **FFTX**, and **CuPy** so setup finishes quickly.
+
 Before committing changes, run the following commands:
 
 ```bash

--- a/run/setup.sh
+++ b/run/setup.sh
@@ -7,6 +7,6 @@ python3 -m pip install --upgrade pip
 # Install base Python dependencies
 pip install --prefer-binary -r requirements.txt
 
-# Attempt to install optional GPU libraries. Installation failures are ignored
-pip install cupy || echo "cupy installation failed; falling back to NumPy"
-pip install fftx || echo "fftx installation failed; using numpy.fft"
+# Optional GPU libraries (CuPy, FFTX, Spiral) are intentionally skipped to
+# keep setup time under two minutes. The code will automatically fall back to
+# NumPy implementations when these packages are unavailable.

--- a/test_scripts/get_charge_density.py
+++ b/test_scripts/get_charge_density.py
@@ -1,5 +1,5 @@
 import numpy as np
-from gpu_utils import cp, xp, fftx, GPU_AVAILABLE
+from gpu_utils import cp, xp, GPU_AVAILABLE
 import h5py as h5
 import datetime
 
@@ -15,7 +15,7 @@ epspath = 'epsmat.h5'
 eps0path = 'eps0mat.h5'
 
 def perform_fft_3d(data_1d, gvecs, fft_grid):
-    """Transform 1D complex array to real space using FFTX.
+    """Transform 1D complex array to real space using an FFT.
     
     Args:
         data_1d: 1D complex array of coefficients (length ngk[ik])
@@ -39,16 +39,16 @@ def perform_fft_3d(data_1d, gvecs, fft_grid):
     # Use advanced indexing to assign all values at once
     fft_box[ix, iy, iz] = data_1d
     
-    # Perform inverse FFT using FFTX
+    # Perform inverse FFT using CuPy if available, otherwise NumPy
     # Note: ifftn performs the inverse FFT which is what we want for G-space to real-space
-    fft_result = fftx.fft.ifftn(fft_box)
+    fft_result = xp.fft.ifftn(fft_box)
     
     return fft_result
 
 def calculate_charge_density(wfn, sym, nval=None, ncond=None):
     """
-    Calculate charge density in real space from wavefunctions using WFNReader: goes over all occ. states c_nk(G),
-    FFTs them to c_nk(R) (using GPU for FFTs when available via FFTX), squares and sums to get rho(R).
+    Calculate charge density in real space from wavefunctions using WFNReader: goes over all occupied states c_nk(G),
+    FFTs them to c_nk(R) (using GPU acceleration when available), squares and sums to get rho(R).
     k-point symmetries are used. The loop order is (nband, nk_irr, n_sym).
     n_sym is done on the GPU since symmetry operations over Gvecs can be parallelized.
     """


### PR DESCRIPTION
## Summary
- streamline agent setup by skipping heavyweight GPU libs
- document the lightweight setup in `AGENTS.md`
- rely on `xp.fft` in charge density helper

## Testing
- `pytest -q`
- `python cohsex_isdf.py`

------
https://chatgpt.com/codex/tasks/task_e_6876882f0e84832787c7a8708532e91d